### PR TITLE
Bump limits from 0.41 to 5 per second

### DIFF
--- a/pkg/server/service_account.go
+++ b/pkg/server/service_account.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	GuestLimits = &hznpb.Account_Limits{
-		HttpRequests: 25 / 60.0,   // per second
+		HttpRequests: 5,           // per second
 		Bandwidth:    1024 / 60.0, // in KB/second
 	}
 )


### PR DESCRIPTION
We need to bump the limits so that apps with images, etc work.

We might want to rethink how the limits are taken to allow for burst windows of like 20 seconds in a few seconds but then cap the total requests per hour to some level as well.