### PR TITLE
Remove jfrog references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# syntax = hashicorp.jfrog.io/docker/docker/dockerfile:experimental
+# syntax = docker.mirror.hashicorp.services/docker/dockerfile:experimental
 
-FROM hashicorp.jfrog.io/docker/golang:alpine AS builder
+FROM docker.mirror.hashicorp.services/golang:alpine AS builder
 
 RUN apk add --no-cache git gcc libc-dev openssh
 
@@ -23,7 +23,7 @@ WORKDIR /tmp/src
 
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=ssh go build -o /tmp/waypoint-hzn -ldflags "-X main.sha1ver=`git rev-parse HEAD` -X main.buildTime=$(date +'+%FT%T.%N%:z')" ./cmd/waypoint-hzn
 
-FROM hashicorp.jfrog.io/docker/alpine
+FROM docker.mirror.hashicorp.services/alpine
 
 COPY --from=builder /tmp/waypoint-hzn /usr/bin/waypoint-hzn
 


### PR DESCRIPTION
This removes all references to `hashicorp.jfrog.io` which has been replaced with a self-hosted registry, `docker.mirror.hashicorp.services`. The registry at `hashicorp.jfrog.io` will be deprecated on March 1, 2021. Please feel free to merge at your convenience 